### PR TITLE
Update execute_script and execute_async_script doc strings

### DIFF
--- a/py/selenium/webdriver/remote/webdriver.py
+++ b/py/selenium/webdriver/remote/webdriver.py
@@ -473,7 +473,7 @@ class WebDriver(object):
          - \*args: Any applicable arguments for your JavaScript.
 
         :Usage:
-            driver.execute_script('document.title')
+            driver.execute_script('return document.title')
         """
         converted_args = list(args)
         command = None
@@ -495,7 +495,7 @@ class WebDriver(object):
          - \*args: Any applicable arguments for your JavaScript.
 
         :Usage:
-            driver.execute_async_script('document.title')
+            driver.execute_async_script('return document.title')
         """
         converted_args = list(args)
         if self.w3c:


### PR DESCRIPTION
Per #4393 , the doc strings for execute_script and execute_async_script are incorrect. This commit adds a return to the two "usage" sections, fixing the errors that would occur without

- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
